### PR TITLE
#49 feat: 반복 내역 추가 및 삭제 응답 소요시간 체크를 위한 timer, 로딩 추가

### DIFF
--- a/Floney/Source/Main/Home/SettingBook/ManageRepeatLineView.swift
+++ b/Floney/Source/Main/Home/SettingBook/ManageRepeatLineView.swift
@@ -18,6 +18,8 @@ struct ManageRepeatLineView: View {
     @State var deleteAlert = false
     @State var title = "반복 내역 삭제"
     @State var message = "반복 내역을 삭제하시겠습니까?\n해당 반복의 모든 내역이 삭제됩니다."
+    @State private var secondsElapsed = 1
+    @State private var timer: Timer?
     var body: some View {
         ZStack {
             VStack(spacing:0) {
@@ -129,6 +131,9 @@ struct ManageRepeatLineView: View {
             .onAppear{
                 viewModel.categoryType = "OUTCOME"
                 viewModel.getRepeatLine()            }
+            .onDisappear {
+                stopTimer()
+            }
             .onChange(of: selectedOptions) { newValue in
                 if options[newValue] == "지출" {
                     viewModel.categoryType = "OUTCOME"
@@ -172,11 +177,37 @@ struct ManageRepeatLineView: View {
             )
             if deleteAlert {
                 FloneyAlertView(isPresented: $deleteAlert, title:$title, message: $message, leftButtonText:"삭제하기") {
-                    viewModel.deleteAllRepeatLine(bookLineKey: self.selectedRepeatLineId)
+                    viewModel.deleteRepeatLine(repeatLineId: self.selectedRepeatLineId)
+                    startTimer()
                 }
-                
+            }
+            if viewModel.isApiCalling {
+                LoadingView()
+                ZStack {
+                    VStack {
+                        Spacer()
+                        Text("\(secondsElapsed) 초 경과")
+                            .foregroundColor(.white)
+                            .font(.pretendardFont(.medium,size:18))
+                            .padding(.bottom, 60)
+                    }
+                }
             }
         }
+    }
+    func startTimer() {
+        secondsElapsed = 1
+        timer?.invalidate() // 기존 타이머가 있다면 중지
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+            DispatchQueue.main.async {
+                self.secondsElapsed += 1
+            }
+        }
+    }
+    
+    func stopTimer() {
+        timer?.invalidate()
+        timer = nil
     }
 }
 

--- a/Floney/Source/Main/Home/SettingBook/ViewModel/ManageRepeatLineViewModel.swift
+++ b/Floney/Source/Main/Home/SettingBook/ViewModel/ManageRepeatLineViewModel.swift
@@ -17,6 +17,7 @@ class ManageRepeatLineViewModel : ObservableObject {
     @Published var tokenViewModel = TokenReissueViewModel()
     @Published var categoryType = ""
     @Published var repeatLineList : [RepeatLineResponse] = []
+    @Published var isApiCalling: Bool = false
     
     private var cancellableSet: Set<AnyCancellable> = []
     var dataManager: ManageRepeatLineProtocol
@@ -47,14 +48,19 @@ class ManageRepeatLineViewModel : ObservableObject {
     }
     
     func deleteRepeatLine(repeatLineId: Int) {
+        guard !isApiCalling else { return }
+        isApiCalling = true
         let request = DeleteRepeatLineRequest(repeatLineId: repeatLineId)
         dataManager.deleteRepeatLine(parameters: request)
             .sink { completion in
                 switch completion {
                 case .finished:
+                    self.isApiCalling = false
                     print("반복 내역 삭제 성공")
+                    self.getRepeatLine()
                 case .failure(let error):
                     print(error)
+                    self.isApiCalling = false
                     self.createAlert(with: error, retryRequest: {
                         self.deleteRepeatLine(repeatLineId: repeatLineId)
                     })
@@ -66,14 +72,18 @@ class ManageRepeatLineViewModel : ObservableObject {
     }
     
     func deleteAllRepeatLine(bookLineKey: Int) {
+        guard !isApiCalling else { return }
+        isApiCalling = true
         let request = DeleteAllRepeatLineRequest(bookLineKey: bookLineKey)
         dataManager.deleteAllRepeatLine(parameters: request)
             .sink { completion in
                 switch completion {
                 case .finished:
+                    self.isApiCalling = false
                     print("반복 내역 모두 삭제 성공")
                 case .failure(let error):
                     print(error)
+                    self.isApiCalling = false
                     self.createAlert(with: error, retryRequest: {
                         self.deleteAllRepeatLine(bookLineKey: bookLineKey)
                     })


### PR DESCRIPTION
## 📌 개요

반복 내역 추가, 삭제 로딩

## ✅ 개발 내용

- api 요청 status를 감지하여 로딩 뷰 및 소요시간 추가