### PR TITLE
#90 feat: 화폐 단위 추가

### DIFF
--- a/Floney/Source/Main/Home/SettingBook/SetCurrencyUnitView.swift
+++ b/Floney/Source/Main/Home/SettingBook/SetCurrencyUnitView.swift
@@ -15,7 +15,9 @@ struct SetCurrencyUnitView: View {
     @State var title = "가계부가 초기화됩니다"
     @State var message = ""
     @State var selectedUnit = ""
-    @State var currencyUnits = ["KRW(원)","USD($)","EUR(€)","JPY(¥)","CNY(¥)","GBP(£)"]
+    @State var currencyUnits = ["KRW(원)","USD($)","EUR(€)","JPY(¥)","CNY(¥)","GBP(£)",
+                                "VND(đ)", "PHP(₱)", "THB(฿)", "IDR(Rp)", "MYR(RM)", "TRY(₺)", "RUB(₽)", "HUF(Ft)", "CHF(Fr)", "INR(₹)", "PLN(zł)", "CZK(Kč)", "DKK(kr)", "NGN(₦)"
+]
     @State var isSelected = 0
     @State var newCurrency : String = ""
 

--- a/Floney/Util/CurrencyManager.swift
+++ b/Floney/Util/CurrencyManager.swift
@@ -68,6 +68,48 @@ class CurrencyManager: ObservableObject {
         case "GBP":
             currentCurrency = "£"
             hasDecimalPoint = true
+        case "VND":
+            currentCurrency = "đ"
+            hasDecimalPoint = false
+        case "PHP":
+            currentCurrency = "₱"
+            hasDecimalPoint = true
+        case "THE":
+            currentCurrency = "฿"
+            hasDecimalPoint = true
+        case "IDR":
+            currentCurrency = "Rp"
+            hasDecimalPoint = true
+        case "MYR":
+            currentCurrency = "RM"
+            hasDecimalPoint = true
+        case "TRY":
+            currentCurrency = "₺"
+            hasDecimalPoint = true
+        case "RUB":
+            currentCurrency = "₽"
+            hasDecimalPoint = true
+        case "HUF":
+            currentCurrency = "Ft"
+            hasDecimalPoint = true
+        case "CHF":
+            currentCurrency = "Fr"
+            hasDecimalPoint = true
+        case "INR":
+            currentCurrency = "฿"
+            hasDecimalPoint = true
+        case "PLN":
+            currentCurrency = "zł"
+            hasDecimalPoint = true
+        case "CZK":
+            currentCurrency = "Kč"
+            hasDecimalPoint = true
+        case "DKK":
+            currentCurrency = "kr"
+            hasDecimalPoint = true
+        case "NGN":
+            currentCurrency = "₦"
+            hasDecimalPoint = true
         default:
             currentCurrency = "원"  // 혹은 기본값으로 다른 문자열을 반환
             hasDecimalPoint = false

--- a/Floney/Util/CurrencyManager.swift
+++ b/Floney/Util/CurrencyManager.swift
@@ -74,7 +74,7 @@ class CurrencyManager: ObservableObject {
         case "PHP":
             currentCurrency = "₱"
             hasDecimalPoint = true
-        case "THE":
+        case "THB":
             currentCurrency = "฿"
             hasDecimalPoint = true
         case "IDR":
@@ -96,7 +96,7 @@ class CurrencyManager: ObservableObject {
             currentCurrency = "Fr"
             hasDecimalPoint = true
         case "INR":
-            currentCurrency = "฿"
+            currentCurrency = "₹"
             hasDecimalPoint = true
         case "PLN":
             currentCurrency = "zł"
@@ -114,9 +114,5 @@ class CurrencyManager: ObservableObject {
             currentCurrency = "원"  // 혹은 기본값으로 다른 문자열을 반환
             hasDecimalPoint = false
         }
-        
-        print("Currency :", currentCurrency)
-        print("has decimal point :", hasDecimalPoint)
     }
-    
 }


### PR DESCRIPTION
## 📌 개요

화폐 단위 추가

## ✅ 개발 내용

- 화폐 지원 단위 추가 : VND(đ), PHP(₱), THB(฿), IDR(Rp), MYR(RM), TRY(₺), RUB(₽), HUF(Ft), CHF(Fr), INR(₹), PLN(zł), CZK(Kč), DKK(kr), NGN(₦)
